### PR TITLE
Openshift

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,9 @@
 
         
         <dependency>
-            <groupId>de.muenchen.referenzarchitektur</groupId>
-            <artifactId>lhm_animad_admin_html5</artifactId>
-            <version>${project.version}</version>
+            <groupId>de.muenchen.animad.admin</groupId>
+            <artifactId>animad-gui-keeperinterface</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
             <scope>runtime</scope>
         </dependency>   
         

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,12 +16,12 @@ zuul:
   routes:
     user:
       path: /api/user_service/**
-      url: http://localhost:8870/
+      url: http://user-service:8080/
 #      sensitiveHeaders: 
       add-proxy-headers: true
     admin:
       path: /api/admin_service/**
-      url: http://localhost:39146/
+      url: http://admin-service:8080/
 #      sensitiveHeaders: 
       add-proxy-headers: true
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,12 +37,12 @@ security:
   oauth2:
     client:
       clientId: openIdDemo
-      clientSecret: b0c2bbe0-ba2f-454c-85ad-59a08cc09e6c
+      clientSecret: f33048d1-82be-42de-81d9-71356ab8b19d
       accessTokenUri: http://localhost:8080/auth/realms/demo/protocol/openid-connect/token
       userAuthorizationUri: http://localhost:8080/auth/realms/demo/protocol/openid-connect/auth
     resource:
       jwt:
-        key-value: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqjrVO6S3X8U79FSJgY/zKBvEe+YOYAVRnjeaZLaFs66Amglf1RLp1G2ZANCtEV35uPOWi3ErkQDvGEOn0BNlgxYFI6iPO2co6RnPIRNEIhp7uvw9mxevXmIcRfv0/bulus81ET7H/POYqYpr7zXaN1EQU5nhjsSF39AHC5Xp49Fve8fihtWu63JOd/WnlkxJ+esxl+q+Wx1wBKdY8eaIxrKs3REZV0wxrSq7qwBEgAJ5HAojz3SO/A6s4K/J0Fm1WCxsnkm9LJ+gtnfDltYoJDbZafQyifT45oHz0pApIScqbsvgriOjQxSrQ7XzUx9btMxoKdPHrjlTukGweInqlQIDAQAB
+        key-value: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlsteeVtC+LlM/uhuusceFDvKbeCPolBEpq+rNnRbBvSPDCdKGcIIpjrQswX/58loE/bQ45A5IY1Tlm1MWbGxZ0IZhYaILeTNySTK3aRsV94OpN+ib/PGWkP1aQZ6wdm4//C6whOhCbulbLwSTyjByD72FGdaO/OhrATD9OAEcP0QmrvjLRHQBA80lxB4fRCyIrea9aL/AuvBsAbTz1Ub70rH8ydwaPtev7/L4dY+9NaqoL23pLIYyV7k3cuPeyHU/lt4I68R4rNiFv08zQFWGMr+li13cWNi9KsNfP5h6Ce7h+D2WmOUv7Tm9b8rAJ4jGHuf8ylHWt0SQxBtofuldwIDAQAB
        
   sessions: ALWAYS
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ zuul:
 #      sensitiveHeaders: 
       add-proxy-headers: true
     admin:
-      path: /api/admin_service/**
+      path: /api/animad-service-administration/**
       url: http://localhost:39146/
 #      sensitiveHeaders: 
       add-proxy-headers: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,74 @@ spring:
     profiles.active: local
     application.name: Zuul
 
-# zuul proxy exposes 8082
+
+---
+# LOCAL CONFIGURATION
+spring:
+    profiles: local
+
+server.port: 8082
+
+
+zuul:
+  ignoredServices: '*'
+  routes:
+    user:
+      path: /api/user_service/**
+      url: http://localhost:8870/
+#      sensitiveHeaders: 
+      add-proxy-headers: true
+    admin:
+      path: /api/admin_service/**
+      url: http://localhost:39146/
+#      sensitiveHeaders: 
+      add-proxy-headers: true
+
+
+      
+security:
+  oauth2:
+    client:
+      clientId: openIdDemo
+      clientSecret: f33048d1-82be-42de-81d9-71356ab8b19d
+      accessTokenUri: http://localhost:8080/auth/realms/demo/protocol/openid-connect/token
+      userAuthorizationUri: http://localhost:8080/auth/realms/demo/protocol/openid-connect/auth
+    resource:
+      jwt:
+        key-value: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlsteeVtC+LlM/uhuusceFDvKbeCPolBEpq+rNnRbBvSPDCdKGcIIpjrQswX/58loE/bQ45A5IY1Tlm1MWbGxZ0IZhYaILeTNySTK3aRsV94OpN+ib/PGWkP1aQZ6wdm4//C6whOhCbulbLwSTyjByD72FGdaO/OhrATD9OAEcP0QmrvjLRHQBA80lxB4fRCyIrea9aL/AuvBsAbTz1Ub70rH8ydwaPtev7/L4dY+9NaqoL23pLIYyV7k3cuPeyHU/lt4I68R4rNiFv08zQFWGMr+li13cWNi9KsNfP5h6Ce7h+D2WmOUv7Tm9b8rAJ4jGHuf8ylHWt0SQxBtofuldwIDAQAB
+  sessions: ALWAYS
+
+endpoints.routes.sensitive: false
+       
+logging:
+  level:
+    org.springframework.security: DEBUG
+    org.springframework.web: DEBUG      
+      
+---
+# DOCKER CONFIGURATION
+spring:
+    profiles: docker
+---
+# NO-SECURITY CONFIGURATION
+spring:
+    profiles: no-security
+    h2.console.enabled: true
+
+security.ignored: /**    
+
+server.port: 8082
+
+
+      
+---
+# OPENSHIFT CONFIGURATION
+spring:
+    profiles: openshift
+    h2.console.enabled: true
+
+security.ignored: /**    
+
 server.port: 8080
 
 # zuul routes
@@ -23,43 +90,4 @@ zuul:
       path: /api/admin_service/**
       url: http://admin-service:8080/
 #      sensitiveHeaders: 
-      add-proxy-headers: true
-
----
-# LOCAL CONFIGURATION
-spring:
-    profiles: local
-      
-
-
-      
-security:
-  oauth2:
-    client:
-      clientId: openIdDemo
-      clientSecret: f33048d1-82be-42de-81d9-71356ab8b19d
-      accessTokenUri: http://localhost:8080/auth/realms/demo/protocol/openid-connect/token
-      userAuthorizationUri: http://localhost:8080/auth/realms/demo/protocol/openid-connect/auth
-    resource:
-      jwt:
-        key-value: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlsteeVtC+LlM/uhuusceFDvKbeCPolBEpq+rNnRbBvSPDCdKGcIIpjrQswX/58loE/bQ45A5IY1Tlm1MWbGxZ0IZhYaILeTNySTK3aRsV94OpN+ib/PGWkP1aQZ6wdm4//C6whOhCbulbLwSTyjByD72FGdaO/OhrATD9OAEcP0QmrvjLRHQBA80lxB4fRCyIrea9aL/AuvBsAbTz1Ub70rH8ydwaPtev7/L4dY+9NaqoL23pLIYyV7k3cuPeyHU/lt4I68R4rNiFv08zQFWGMr+li13cWNi9KsNfP5h6Ce7h+D2WmOUv7Tm9b8rAJ4jGHuf8ylHWt0SQxBtofuldwIDAQAB
-       
-  sessions: ALWAYS
-
-endpoints.routes.sensitive: false
-       
-logging:
-  level:
-    org.springframework.security: DEBUG
-    org.springframework.web: DEBUG      
-      
----
-# DOCKER CONFIGURATION
-spring:
-    profiles: docker
----
-spring:
-    profiles: no-security
-    h2.console.enabled: true
-
-security.ignored: /**    
+      add-proxy-headers: true 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
     application.name: Zuul
 
 # zuul proxy exposes 8082
-server.port: 8082
+server.port: 8080
 
 # zuul routes
 zuul:


### PR DESCRIPTION
Benötigt die Branches "openshift" von
- html5
- api-gateway
- admin-service
- user-service

Es gibt nun ein neues Profil "openshift". Dieses lässt sich wie folgt nutzen:

1. Lokal starten ohne Security
mvn spring-boot:run -Dspring.profiles.active=local,no-security

2. Lokal starten mit Security
mvn spring-boot:run
(Profil "local" ist das Standardprofil)

3. Auf Openshift starten ohne Security
mvn spring-boot:run -Dspring.profiles.active=openshift,no-security

(zukünftig, noch nicht in diesem PR, kommt dann noch
4. Auf Openshift starten mit Security
mvn spring-boot:run -Dspring.profiles.active=openshift
oder sogar (wenn wir das Standard-Profil auf "openshift" stellen)
mvn spring-boot:run)

**Achtung:**
mvn spring-boot:run -Dspring.profiles.active=no-security
ist KEINE valide Option mehr.